### PR TITLE
added docs for using Gradle

### DIFF
--- a/bootique-logback-docs/src/main/asciidoc/_chapters/_01_intro.adoc
+++ b/bootique-logback-docs/src/main/asciidoc/_chapters/_01_intro.adoc
@@ -25,6 +25,9 @@ https://github.com/bootique/bootique-logback[`bootique-logback`] is a "drag-and-
 logging with http://logback.qos.ch/[Logback logging framework]. Just like any other module, `bootique-logback` can be
 enabled by simply adding it to the `pom.xml` dependencies, assuming `autoLoadModules()` is in effect:
 
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -32,6 +35,18 @@ enabled by simply adding it to the `pom.xml` dependencies, assuming `autoLoadMod
     <artifactId>bootique-logback</artifactId>
 </dependency>
 ----
+====
+
+.Gradle
+[%collapsible]
+====
+[source,groovy]
+----
+{
+  implementation: 'io.bootique.logback:bootique-logback'
+}
+----
+====
 
 Without further configuration it would log everything to console using INFO level. Configuration can be provided via
 YAML, as shown in the <<_configuration_reference,Configuration Reference>> section. Configuration options include per

--- a/bootique-logback-docs/src/main/asciidoc/_chapters/_04_sentry.adoc
+++ b/bootique-logback-docs/src/main/asciidoc/_chapters/_04_sentry.adoc
@@ -25,8 +25,9 @@ Get DSN (Data Source Name) from https://sentry.io/[sentry.io] or from your own i
 
 === Add bootique-logback-sentry to your build tool:
 
-*Maven*
-
+.Maven
+[%collapsible%open]
+====
 [source,xml]
 ----
 <dependency>
@@ -34,13 +35,16 @@ Get DSN (Data Source Name) from https://sentry.io/[sentry.io] or from your own i
     <artifactId>bootique-logback-sentry</artifactId>
 </dependency>
 ----
+====
 
-*Gradle*
-
+.Gradle
+[%collapsible]
+====
 [source,kotlin,subs="attributes"]
 ----
 compile("io.bootique.logback:bootique-logback-sentry:{bootique_version}")
 ----
+====
 
 NOTE: *bootique-logback-sentry* is a part of https://github.com/bootique/bootique-bom[bootique-bom], and version can be
 imported from there.

--- a/bootique-logback-docs/src/main/asciidoc/index.adoc
+++ b/bootique-logback-docs/src/main/asciidoc/index.adoc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-:bq-header: _index/header.html
+:bq-header: _chapters/header.html
 
 = Bootique Logback Documentation
 


### PR DESCRIPTION
Sample Maven and Gradle dependencies are provided as dropdown text. Maven dependencies are open by default.