### PR TITLE
fix: context for the policy should be instantiated the first

### DIFF
--- a/bootique-logback/src/main/java/io/bootique/logback/policy/SizeAndTimeBasedPolicyFactory.java
+++ b/bootique-logback/src/main/java/io/bootique/logback/policy/SizeAndTimeBasedPolicyFactory.java
@@ -56,11 +56,11 @@ public class SizeAndTimeBasedPolicyFactory extends TimeBasedPolicyFactory {
 	@Override
 	protected SizeAndTimeBasedRollingPolicy<ILoggingEvent> instantiatePolicy(LoggerContext context) {
 		SizeAndTimeBasedRollingPolicy<ILoggingEvent> policy = new SizeAndTimeBasedRollingPolicy<>();
+		policy.setContext(context);
 		setupBasePolicySettings(policy);
 		if (fileSize != null && fileSize.length() > 0) {
 			policy.setMaxFileSize(FileSize.valueOf(fileSize));
 		}
-		policy.setContext(context);
 		return policy;
 	}
 

--- a/bootique-logback/src/main/java/io/bootique/logback/policy/TimeBasedPolicyFactory.java
+++ b/bootique-logback/src/main/java/io/bootique/logback/policy/TimeBasedPolicyFactory.java
@@ -59,8 +59,8 @@ public class TimeBasedPolicyFactory extends RollingPolicyFactory {
     @Override
     protected TimeBasedRollingPolicy<ILoggingEvent> instantiatePolicy(LoggerContext context) {
 		TimeBasedRollingPolicy<ILoggingEvent> policy = new TimeBasedRollingPolicy<>();
+        policy.setContext(context);
         setupBasePolicySettings(policy);
-		policy.setContext(context);
 		return policy;
     }
 


### PR DESCRIPTION
#52 
- move context initialization to the first step of the policy configuration